### PR TITLE
feat: add fetch timeout and bounded retry handling for Steam API requests

### DIFF
--- a/src/steam-api.test.ts
+++ b/src/steam-api.test.ts
@@ -316,7 +316,7 @@ describe('steam-api', () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw after max retries exhausted on 5xx', async () => {
+    it('should return final 5xx response after max retries exhausted', async () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValue({ ok: false, status: 500 });
 
@@ -418,21 +418,27 @@ describe('steam-api', () => {
     });
 
     it('should respect Retry-After header on 429', async () => {
-      const headers = new Headers({ 'Retry-After': '1' });
-      (global.fetch as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce({ ok: false, status: 429, headers })
-        .mockResolvedValueOnce({ ok: true, status: 200 });
+      vi.useFakeTimers();
+      try {
+        const headers = new Headers({ 'Retry-After': '1' });
+        (global.fetch as ReturnType<typeof vi.fn>)
+          .mockResolvedValueOnce({ ok: false, status: 429, headers })
+          .mockResolvedValueOnce({ ok: true, status: 200 });
 
-      const start = Date.now();
-      const result = await fetchWithRetry('https://example.com', undefined, {
-        initialDelayMs: 1,
-        maxRetries: 1,
-      });
-      const elapsed = Date.now() - start;
+        const retryPromise = fetchWithRetry('https://example.com', undefined, {
+          initialDelayMs: 1,
+          maxRetries: 1,
+        });
 
-      expect(result.ok).toBe(true);
-      // Retry-After: 1 means 1 second = 1000ms delay
-      expect(elapsed).toBeGreaterThanOrEqual(900);
-    }, 10_000);
+        // Retry-After: 1 means 1 second = 1000ms delay
+        await vi.advanceTimersByTimeAsync(1000);
+
+        const result = await retryPromise;
+        expect(result.ok).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/src/steam-api.ts
+++ b/src/steam-api.ts
@@ -70,12 +70,22 @@ export async function fetchWithRetry(
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const timeoutSignal = AbortSignal.timeout(timeoutMs);
-      const signal = init?.signal
-        ? AbortSignal.any([init.signal, timeoutSignal])
-        : timeoutSignal;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () =>
+        controller.abort(
+          new DOMException(
+            `Request timed out after ${timeoutMs}ms`,
+            "TimeoutError",
+          ),
+        ),
+      timeoutMs,
+    );
+    const signal = init?.signal
+      ? AbortSignal.any([init.signal, controller.signal])
+      : controller.signal;
 
+    try {
       const res = await fetch(url, {
         ...init,
         signal,
@@ -116,6 +126,8 @@ export async function fetchWithRetry(
       }
 
       throw error;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
## Summary

Add a shared `fetchWithRetry` helper in `steam-api.ts` that applies timeout and bounded retry handling to all Steam API requests. This is the foundational infrastructure fix that unblocks 8 downstream issues.

## Changes

- **`src/steam-api.ts`** — Added exported `fetchWithRetry` helper:
  - 15s timeout via `AbortSignal.timeout()` per request
  - Exponential backoff retry on transient failures (429, 5xx, network errors, timeouts)
  - No retry on 4xx auth/privacy/validation failures
  - `Retry-After` header support on 429 (capped at 30s)
  - Signal composition via `AbortSignal.any()` (preserves caller abort signals)
  - Response body cleanup before retry (`res.body?.cancel()`)
  - All 10 bare `fetch()` calls migrated to use the helper

- **`src/steam-api.test.ts`** — 11 new tests covering:
  - Timeout behavior
  - Retry on 5xx, 429, network errors, timeouts
  - Max retries exhausted
  - Retry-After header respect
  - Non-retryable error passthrough
  - Updated 5 existing assertions for new fetch call signature

## Verification

- Typecheck: ✅ clean
- Lint: ✅ clean  
- Tests: ✅ 27 passed (up from 16 baseline)
- Adversarial code review (GPT-5.3-Codex): 2 findings fixed before commit

## Acceptance Criteria (from #3)

- [x] All network requests use a shared helper
- [x] Requests time out after a bounded interval (15s)
- [x] Retries are limited (max 2) and only apply to transient failures
- [x] Existing callers still receive meaningful error messages
- [x] Tests cover timeout and retry behavior

Closes #3