### PR TITLE
fix: guard fetchAppList pagination against runaway loops

### DIFF
--- a/src/steam-api.test.ts
+++ b/src/steam-api.test.ts
@@ -6,7 +6,6 @@ import {
   fetchNews,
   fetchOwnedGames,
   fetchWithRetry,
-  MAX_APP_LIST_PAGES,
 } from './steam-api.js';
 
 // Mock fetch globally
@@ -332,23 +331,25 @@ describe('steam-api', () => {
       );
     });
 
-    it('should stop after MAX_APP_LIST_PAGES iterations and log warning', async () => {
-      const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    it('should stop after max page iterations and log warning', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       try {
-        for (let i = 0; i < MAX_APP_LIST_PAGES; i++) {
+        // Internal cap is 20 pages — mock exactly that many
+        const maxPages = 20;
+        for (let i = 0; i < maxPages; i++) {
           const appid = (i + 1) * 1000;
           (global.fetch as ReturnType<typeof vi.fn>)
             .mockResolvedValueOnce(mockPage([{ appid, name: `Game ${i}` }], true, appid));
         }
 
         const result = await fetchAppList('test-key');
-        expect(result).toHaveLength(MAX_APP_LIST_PAGES);
-        expect(global.fetch).toHaveBeenCalledTimes(MAX_APP_LIST_PAGES);
-        expect(warnSpy).toHaveBeenCalledWith(
+        expect(result).toHaveLength(maxPages);
+        expect(global.fetch).toHaveBeenCalledTimes(maxPages);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
           expect.stringContaining('pagination stopped')
         );
       } finally {
-        warnSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
       }
     });
 

--- a/src/steam-api.ts
+++ b/src/steam-api.ts
@@ -139,7 +139,7 @@ export async function fetchWithRetry(
 // --- Steam API fetch functions ---
 
 // ~240k apps at 50k/page = ~5 pages; 20 is generous headroom.
-export const MAX_APP_LIST_PAGES = 20;
+const MAX_APP_LIST_PAGES = 20;
 
 export async function fetchAppList(apiKey: string): Promise<SteamApp[]> {
   const allApps: SteamApp[] = [];
@@ -182,7 +182,7 @@ export async function fetchAppList(apiKey: string): Promise<SteamApp[]> {
       throw new Error(
         `App list pagination stuck: last_appid did not advance ` +
         `(was ${lastAppId}, got ${newLastAppId}) on page ${page + 1}. ` +
-        `Collected ${allApps.length} apps so far.`
+        `Collected ${allApps.length - apps.length} apps before failure.`
       );
     }
     lastAppId = newLastAppId;


### PR DESCRIPTION
## Summary

Hardens etchAppList in src/steam-api.ts by adding defensive termination conditions to the pagination loop.

## Changes

- **Bounded loop**: Replaced unbounded \while(true)\ with \or\ loop capped at \MAX_APP_LIST_PAGES\ (20 — generous headroom over the ~5 pages needed for ~240k apps at 50k/page)
- **Stale progress detection**: Throws a descriptive error if \last_appid\ does not advance (stuck or backwards), including the iteration count and total apps collected for diagnosis
- **Truncation warning**: Logs via \console.error\ when pagination hits the page cap, so partial results are observable rather than silent
- **8 new unit tests**: Multi-page pagination, empty-name filtering, empty page termination, stuck/backwards \last_appid\, max-iteration cap with warning assertion, HTTP errors, and empty first page

## Verification

- Typecheck: ✅ \	sc --noEmit\
- Lint: ✅ \slint\
- Tests: ✅ 35/35 passed (was 27)
- IDE diagnostics: ✅ Zero errors
- Adversarial review (GPT-5.3-Codex): Caught silent truncation on max-page exit → fixed with \completedNaturally\ flag + \console.error\ warning

Closes #4