### PR TITLE
Fix concurrent app-list initialization

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -15,6 +15,7 @@ describe('cache', () => {
 
   afterEach(() => {
     vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   describe('searchApps', () => {
@@ -83,6 +84,90 @@ describe('cache', () => {
 
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].app.name).toContain('Dota');
+    });
+
+    it('should share concurrent first-load initialization', async () => {
+      process.env.STEAM_API_KEY = 'test-key';
+
+      const mockApps: SteamApp[] = [
+        { appid: 570, name: 'Dota 2' },
+        { appid: 730, name: 'Counter-Strike 2' },
+      ];
+
+      let resolveFetch!: (apps: SteamApp[]) => void;
+      const fetchPromise = new Promise<SteamApp[]>((resolve) => {
+        resolveFetch = resolve;
+      });
+
+      const { fetchAppList } = await import('./steam-api.js');
+      vi.mocked(fetchAppList).mockImplementationOnce(() => fetchPromise);
+
+      const { searchApps } = await import('./cache.js');
+      const firstSearch = searchApps('dota', 5);
+      const secondSearch = searchApps('counter', 5);
+
+      expect(fetchAppList).toHaveBeenCalledTimes(1);
+
+      resolveFetch(mockApps);
+
+      const [firstResults, secondResults] = await Promise.all([
+        firstSearch,
+        secondSearch,
+      ]);
+
+      expect(fetchAppList).toHaveBeenCalledTimes(1);
+      expect(firstResults[0].app.name).toBe('Dota 2');
+      expect(secondResults[0].app.name).toBe('Counter-Strike 2');
+    });
+
+    it('should allow retry after failed initialization', async () => {
+      process.env.STEAM_API_KEY = 'test-key';
+
+      const mockApps: SteamApp[] = [
+        { appid: 570, name: 'Dota 2' },
+      ];
+
+      const { fetchAppList } = await import('./steam-api.js');
+      vi.mocked(fetchAppList)
+        .mockRejectedValueOnce(new Error('temporary failure'))
+        .mockResolvedValueOnce(mockApps);
+
+      const { searchApps } = await import('./cache.js');
+
+      await expect(searchApps('dota', 5)).rejects.toThrow('temporary failure');
+
+      const results = await searchApps('dota', 5);
+
+      expect(fetchAppList).toHaveBeenCalledTimes(2);
+      expect(results[0].app.appid).toBe(570);
+    });
+
+    it('should refresh after the cache expires', async () => {
+      process.env.STEAM_API_KEY = 'test-key';
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      const initialApps: SteamApp[] = [
+        { appid: 570, name: 'Dota 2' },
+      ];
+      const refreshedApps: SteamApp[] = [
+        { appid: 220, name: 'Half-Life 2' },
+      ];
+
+      const { fetchAppList } = await import('./steam-api.js');
+      vi.mocked(fetchAppList)
+        .mockResolvedValueOnce(initialApps)
+        .mockResolvedValueOnce(refreshedApps);
+
+      const { searchApps } = await import('./cache.js');
+
+      const firstResults = await searchApps('dota', 5);
+      vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1000 + 1);
+      const secondResults = await searchApps('half', 5);
+
+      expect(fetchAppList).toHaveBeenCalledTimes(2);
+      expect(firstResults[0].app.appid).toBe(570);
+      expect(secondResults[0].app.appid).toBe(220);
     });
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,11 +5,17 @@ import type { SteamApp } from "./types.js";
 let appList: SteamApp[] = [];
 let fuseIndex: Fuse<SteamApp> | null = null;
 let lastFetchTime = 0;
+let loadingPromise: Promise<void> | null = null;
 const REFRESH_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
 
 async function ensureLoaded(): Promise<void> {
   const now = Date.now();
   if (appList.length > 0 && now - lastFetchTime < REFRESH_INTERVAL) {
+    return;
+  }
+
+  if (loadingPromise) {
+    await loadingPromise;
     return;
   }
 
@@ -21,16 +27,27 @@ async function ensureLoaded(): Promise<void> {
     );
   }
 
-  console.error("Fetching Steam app list...");
-  appList = await fetchAppList(apiKey);
-  fuseIndex = new Fuse(appList, {
-    keys: ["name"],
-    threshold: 0.3,
-    distance: 200,
-    minMatchCharLength: 2,
-  });
-  lastFetchTime = now;
-  console.error(`Loaded ${appList.length} apps into search index.`);
+  loadingPromise = (async () => {
+    console.error("Fetching Steam app list...");
+    const nextAppList = await fetchAppList(apiKey);
+    const nextFuseIndex = new Fuse(nextAppList, {
+      keys: ["name"],
+      threshold: 0.3,
+      distance: 200,
+      minMatchCharLength: 2,
+    });
+
+    appList = nextAppList;
+    fuseIndex = nextFuseIndex;
+    lastFetchTime = now;
+    console.error(`Loaded ${appList.length} apps into search index.`);
+  })();
+
+  try {
+    await loadingPromise;
+  } finally {
+    loadingPromise = null;
+  }
 }
 
 export interface SearchResult {


### PR DESCRIPTION
## Summary
- share a single in-flight cache initialization so concurrent search requests do not duplicate the full app-list load
- clear the in-flight state after failed initialization so later searches can retry cleanly
- add regression tests for concurrent cold starts, retry-after-failure, and TTL-based refresh behavior

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build

Fixes #5